### PR TITLE
Add conversations manifest for Codes And Standards handover

### DIFF
--- a/output/handover_final/conversations_manifest.json
+++ b/output/handover_final/conversations_manifest.json
@@ -1,0 +1,130 @@
+{
+  "project": "Codes And Standards",
+  "version": "2025-09-09",
+  "conversations": [
+    {
+      "index": "C-001",
+      "short_title": "Generative doc system",
+      "descriptive_title": "Generate Word-equivalent artefacts (Word/Excel/PowerPoint) as baseline",
+      "date": "2025-09-01",
+      "groups": ["Integration", "ADR", "SoR-link"],
+      "bios": {
+        "manifest": ["artefact_manifest.json", "GOLDEN_THREAD.md"],
+        "handover": ["handover_notes.md", "deepagent_handover.json"],
+        "architecture": ["KE_BLOCKS.md", "roundtrip_flow.ascii"],
+        "operational": ["make forward", "make roundtrip"],
+        "user_requirement": ["RTM integration hooks"],
+        "inputs": ["MASTER.docx", "pipeline.yml"],
+        "outputs": ["*.docx", "*.md", "*.xlsx", "*.pptx"],
+        "canvas": true
+      }
+    },
+    {
+      "index": "C-002",
+      "short_title": "Generative documentation system",
+      "descriptive_title": "Forward/backward documentation roundtrip with KE_BLOCKS",
+      "date": "2025-09-01",
+      "groups": ["Integration", "ADR"],
+      "bios": {
+        "manifest": ["cd.yml", "ci.yml", "dmaic.yml"],
+        "handover": ["handover_playbook.md"],
+        "architecture": ["roundtrip_diagram.ascii"],
+        "operational": ["python pipeline/main.py --roundtrip"],
+        "user_requirement": ["Roundtrip fidelity >=99%"],
+        "inputs": ["MASTER.docx", "cfg.toml"],
+        "outputs": ["roundtrip_report.md", "delta.csv"],
+        "canvas": true
+      }
+    },
+    {
+      "index": "C-003",
+      "short_title": "WBS and Quality Assurance",
+      "descriptive_title": "WBS realignment + QA traceability spine",
+      "date": "2025-03-28",
+      "groups": ["PLANNING/SCHEDULE", "OCD"],
+      "bios": {
+        "manifest": ["wbs_map.json"],
+        "handover": ["qa_trace.md"],
+        "architecture": ["wbs_to_rtm_map.md"],
+        "operational": ["qa_checks.py"],
+        "user_requirement": ["Traceability for each WBS element"],
+        "inputs": ["WBS.xlsx"],
+        "outputs": ["WBS_QA_trace.xlsx", "RTM_links.json"],
+        "canvas": false
+      }
+    },
+    {
+      "index": "C-004",
+      "short_title": "Rationale in RFOs Belgie",
+      "descriptive_title": "Provide rationale structure for public procurement requirements",
+      "date": "2025-03-28",
+      "groups": ["SoR", "ADR"],
+      "bios": {
+        "manifest": ["rfo_rationale_schema.json"],
+        "handover": ["rfo_guidance.md"],
+        "architecture": ["policy_flow.ascii"],
+        "operational": ["rationale_lint.py"],
+        "user_requirement": ["Clause->Rationale mapping"],
+        "inputs": ["RFO clauses (BE)"],
+        "outputs": ["rationale_bank.md"],
+        "canvas": false
+      }
+    },
+    {
+      "index": "C-005",
+      "short_title": "316L SS Purification System",
+      "descriptive_title": "Tabled requirements + QA references for 316L purification",
+      "date": "2025-03-28",
+      "groups": ["SoR", "OCD"],
+      "bios": {
+        "manifest": ["316L_requirements.yaml"],
+        "handover": ["316L_handover.md"],
+        "architecture": ["purification_interfaces.md"],
+        "operational": ["V&V_plan_316L.md"],
+        "user_requirement": ["Material, cleanliness, test criteria"],
+        "inputs": ["Spec refs", "Standards list"],
+        "outputs": ["req_table.xlsx", "VnV_matrix.xlsx"],
+        "canvas": false
+      }
+    },
+    {
+      "index": "C-006",
+      "short_title": "DMAIC Codes Standards Integration",
+      "descriptive_title": "Make DMAIC explicit across Codes/Standards workflows",
+      "date": "2025-03-28",
+      "groups": ["Integration", "OCD"],
+      "bios": {
+        "manifest": ["dmaic_kpis.json"],
+        "handover": ["dmaic_handover.md"],
+        "architecture": ["dmaic_flow.ascii"],
+        "operational": ["measure.py", "improve.py", "control.py"],
+        "user_requirement": ["KPIs: schema, CPU eff, variance, fidelity"],
+        "inputs": ["Standards set"],
+        "outputs": ["dmaic_dashboard.md"],
+        "canvas": true
+      }
+    },
+    {
+      "index": "C-007",
+      "short_title": "ISO Standards for Management",
+      "descriptive_title": "ISO management mapping (change, nonconformity, audits)",
+      "date": "2025-02-28",
+      "groups": ["OCD", "SoR"],
+      "bios": {
+        "manifest": ["iso_matrix.json"],
+        "handover": ["iso_policy_overview.md"],
+        "architecture": ["audit_flow.ascii"],
+        "operational": ["audit_checklist.xlsx"],
+        "user_requirement": ["Change mgmt, NC mgmt, audits"],
+        "inputs": ["ISO clauses"],
+        "outputs": ["policy_matrix.md"],
+        "canvas": false
+      }
+    }
+  ],
+  "system_context": {
+    "qcell_ui": "UI touchpoint for ops and review",
+    "acb_dist": "Accelerator Cryogenic Backbone (distribution)",
+    "golden_thread": "MASTER.docx -> RTM -> Artefacts -> V&V"
+  }
+}


### PR DESCRIPTION
## Summary
- add conversations_manifest.json capturing seven project conversations and system context
- replace non-ASCII characters with ASCII equivalents for portability

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c013f7f4b4832ea84641a224b0d35f