### PR TITLE
Add ZIP processing pipeline utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@ Welcome to your shiny new codespace! We've got everything fired up and running f
 You've got a blank canvas to work on from a git perspective as well. There's a single initial commit with what you're seeing right now - where you go from here is up to you!
 
 Everything you do here is contained within this one codespace. There is no repository on GitHub yet. If and when you’re ready you can click "Publish Branch" and we’ll create your repository and push up your project. If you were just exploring then and have no further need for this code then you can simply delete your codespace and it's gone forever.
+
+## ZIP Processing Pipeline
+
+The project includes `src/zip_pipeline.py`, a small utility for sequentially
+processing ZIP archives. For each archive it performs bytecode compilation
+(smoke test), an optional dry run, and integration tests via `pytest`. The
+original ZIP is deleted when processing succeeds.
+
+Run the pipeline by supplying the directories to scan:
+
+```bash
+python -m src.zip_pipeline <dir1> <dir2> ...
+```

--- a/src/zip_pipeline.py
+++ b/src/zip_pipeline.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Utilities for processing collections of ZIP archives.
+
+This module discovers ZIP files inside one or more base directories and
+processes them sequentially.  For each archive the following steps are
+performed:
+
+1. Extract the ZIP to a temporary directory.
+2. Run smoke tests by byte-compiling all Python files.
+3. Run an optional dry run if a ``run_pipeline.py`` script is present.
+4. Execute integration tests via ``pytest``.
+5. Remove the original ZIP file once processing succeeds.
+
+The module is intentionally simple and aims to provide a reliable example
+of how a ZIP processing pipeline could be automated.  It can be invoked as a
+script or its functions can be imported and reused.
+"""
+
+from pathlib import Path
+import subprocess
+import tempfile
+import zipfile
+from typing import Iterable, List
+
+
+def discover_zip_files(base_dirs: Iterable[str]) -> List[Path]:
+    """Return a sorted list of all ``.zip`` files under ``base_dirs``."""
+    paths: List[Path] = []
+    for base in base_dirs:
+        paths.extend(Path(base).rglob("*.zip"))
+    return sorted(paths)
+
+
+def run_smoke_tests(extracted_dir: str | Path) -> None:
+    """Byte-compile all Python files to ensure they are syntactically valid."""
+    extracted = Path(extracted_dir)
+    py_files = list(extracted.rglob("*.py"))
+    if not py_files:
+        return
+    cmd = ["python", "-m", "py_compile", *map(str, py_files)]
+    subprocess.run(cmd, check=True)
+
+
+def run_dry_run(extracted_dir: str | Path) -> None:
+    """Execute ``run_pipeline.py --dry-run`` if the script exists."""
+    candidate = Path(extracted_dir) / "run_pipeline.py"
+    if candidate.exists():
+        subprocess.run(["python", str(candidate), "--dry-run"], check=True)
+
+
+def run_integration_tests(extracted_dir: str | Path) -> None:
+    """Run ``pytest`` inside the extracted directory.
+
+    ``pytest`` returns exit code 5 when no tests are collected.  This is not
+    considered a failure for the purposes of the pipeline.
+    """
+    result = subprocess.run(["pytest"], cwd=extracted_dir)
+    if result.returncode not in (0, 5):
+        raise subprocess.CalledProcessError(result.returncode, result.args)
+
+
+def process_zip(zip_path: str | Path) -> None:
+    """Process ``zip_path`` using the defined pipeline and delete the archive."""
+    zip_path = Path(zip_path)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(tmpdir)
+        run_smoke_tests(tmpdir)
+        run_dry_run(tmpdir)
+        run_integration_tests(tmpdir)
+    zip_path.unlink()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Process ZIP archives")
+    parser.add_argument("base_dirs", nargs="+", help="Directories to search for ZIP files")
+    args = parser.parse_args()
+
+    for zip_file in discover_zip_files(args.base_dirs):
+        process_zip(zip_file)

--- a/tests/test_zip_pipeline.py
+++ b/tests/test_zip_pipeline.py
@@ -1,0 +1,33 @@
+import zipfile
+from pathlib import Path
+
+import zip_pipeline
+
+
+def test_process_zip(tmp_path):
+    # create a simple python file inside a temporary directory
+    simple_py = tmp_path / "example.py"
+    simple_py.write_text("print('hi')\n")
+
+    # create a zip archive containing the python file
+    zip_path = tmp_path / "example.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(simple_py, arcname="example.py")
+
+    # process the zip and ensure it is deleted afterwards
+    zip_pipeline.process_zip(zip_path)
+    assert not zip_path.exists()
+
+
+def test_discover_zip_files(tmp_path):
+    # create nested directories with zip files
+    (tmp_path / "a").mkdir()
+    zip1 = tmp_path / "a" / "one.zip"
+    with zipfile.ZipFile(zip1, "w"):
+        pass
+    zip2 = tmp_path / "two.zip"
+    with zipfile.ZipFile(zip2, "w"):
+        pass
+
+    found = zip_pipeline.discover_zip_files([str(tmp_path)])
+    assert zip1 in found and zip2 in found


### PR DESCRIPTION
## Summary
- add `zip_pipeline` script to process and test ZIP archives sequentially
- document pipeline usage in README
- test ZIP discovery and processing behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c14ebfe704832e97fecfbb3cf8f779