### PR TITLE
Add PPTX slide preview utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,41 @@ Welcome to your shiny new codespace! We've got everything fired up and running f
 You've got a blank canvas to work on from a git perspective as well. There's a single initial commit with what you're seeing right now - where you go from here is up to you!
 
 Everything you do here is contained within this one codespace. There is no repository on GitHub yet. If and when you’re ready you can click "Publish Branch" and we’ll create your repository and push up your project. If you were just exploring then and have no further need for this code then you can simply delete your codespace and it's gone forever.
+
+## ZIP Processing Pipeline
+
+The project includes `src/zip_pipeline.py`, a small utility for sequentially
+processing ZIP archives. For each archive it performs bytecode compilation
+(smoke test), an optional dry run, and integration tests via `pytest`. The
+original ZIP is deleted when processing succeeds.
+
+Run the pipeline by supplying the directories to scan:
+
+```bash
+python -m src.zip_pipeline <dir1> <dir2> ...
+```
+
+## Slide Preview Generator
+
+Use `tools/extract_slide_previews.py` to create quick HTML previews of a PowerPoint deck.
+It writes three files to the chosen output directory:
+
+- `slide_texts.json` – full text content for each slide
+- `slide_digital_twins.json` – compact summary and styling hints
+- `slide_preview.html` – simple visual cards with inline CSS
+
+Run the script like this:
+
+```bash
+python tools/extract_slide_previews.py --pptx path/to/deck.pptx --outdir output --limit 10
+```
+
+The generated HTML uses basic cards per slide:
+
+```html
+<div class='card' style='background:#f0f8ff'>
+  <div class='meta'><span class='num'>#1</span> • shapes:5 • bullets:2</div>
+  <h3 class='title'>SLIDE TITLE</h3>
+  <div class='para'>First bullet item…</div>
+</div>
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8==7.1.1
 pytest==8.3.2
 pytest-cov==5.0.0
+python-pptx==0.6.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas==2.2.2
 torch==2.7.1
 torchvision==0.21.0
 tqdm==4.66.4
+python-pptx==0.6.23

--- a/src/zip_pipeline.py
+++ b/src/zip_pipeline.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Utilities for processing collections of ZIP archives.
+
+This module discovers ZIP files inside one or more base directories and
+processes them sequentially.  For each archive the following steps are
+performed:
+
+1. Extract the ZIP to a temporary directory.
+2. Run smoke tests by byte-compiling all Python files.
+3. Run an optional dry run if a ``run_pipeline.py`` script is present.
+4. Execute integration tests via ``pytest``.
+5. Remove the original ZIP file once processing succeeds.
+
+The module is intentionally simple and aims to provide a reliable example
+of how a ZIP processing pipeline could be automated.  It can be invoked as a
+script or its functions can be imported and reused.
+"""
+
+from pathlib import Path
+import subprocess
+import tempfile
+import zipfile
+from typing import Iterable, List
+
+
+def discover_zip_files(base_dirs: Iterable[str]) -> List[Path]:
+    """Return a sorted list of all ``.zip`` files under ``base_dirs``."""
+    paths: List[Path] = []
+    for base in base_dirs:
+        paths.extend(Path(base).rglob("*.zip"))
+    return sorted(paths)
+
+
+def run_smoke_tests(extracted_dir: str | Path) -> None:
+    """Byte-compile all Python files to ensure they are syntactically valid."""
+    extracted = Path(extracted_dir)
+    py_files = list(extracted.rglob("*.py"))
+    if not py_files:
+        return
+    cmd = ["python", "-m", "py_compile", *map(str, py_files)]
+    subprocess.run(cmd, check=True)
+
+
+def run_dry_run(extracted_dir: str | Path) -> None:
+    """Execute ``run_pipeline.py --dry-run`` if the script exists."""
+    candidate = Path(extracted_dir) / "run_pipeline.py"
+    if candidate.exists():
+        subprocess.run(["python", str(candidate), "--dry-run"], check=True)
+
+
+def run_integration_tests(extracted_dir: str | Path) -> None:
+    """Run ``pytest`` inside the extracted directory.
+
+    ``pytest`` returns exit code 5 when no tests are collected.  This is not
+    considered a failure for the purposes of the pipeline.
+    """
+    result = subprocess.run(["pytest"], cwd=extracted_dir)
+    if result.returncode not in (0, 5):
+        raise subprocess.CalledProcessError(result.returncode, result.args)
+
+
+def process_zip(zip_path: str | Path) -> None:
+    """Process ``zip_path`` using the defined pipeline and delete the archive."""
+    zip_path = Path(zip_path)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(tmpdir)
+        run_smoke_tests(tmpdir)
+        run_dry_run(tmpdir)
+        run_integration_tests(tmpdir)
+    zip_path.unlink()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Process ZIP archives")
+    parser.add_argument("base_dirs", nargs="+", help="Directories to search for ZIP files")
+    args = parser.parse_args()
+
+    for zip_file in discover_zip_files(args.base_dirs):
+        process_zip(zip_file)

--- a/tests/test_extract_slide_previews.py
+++ b/tests/test_extract_slide_previews.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from pptx import Presentation
+
+from tools.extract_slide_previews import extract_slides, write_html_preview
+
+
+def test_extract_and_preview(tmp_path):
+    prs = Presentation()
+    slide_layout = prs.slide_layouts[1]
+    slide = prs.slides.add_slide(slide_layout)
+    slide.shapes.title.text = "TITLE"
+    slide.placeholders[1].text = "- bullet1\nbullet2"
+    pptx_path = tmp_path / "sample.pptx"
+    prs.save(pptx_path)
+
+    slides = extract_slides(pptx_path)
+    assert slides[0]["texts"][0] == "TITLE"
+    html_path = tmp_path / "preview.html"
+    write_html_preview(slides, html_path)
+    assert html_path.exists()
+    content = html_path.read_text()
+    assert "Slide Preview" in content

--- a/tests/test_zip_pipeline.py
+++ b/tests/test_zip_pipeline.py
@@ -1,0 +1,33 @@
+import zipfile
+from pathlib import Path
+
+import zip_pipeline
+
+
+def test_process_zip(tmp_path):
+    # create a simple python file inside a temporary directory
+    simple_py = tmp_path / "example.py"
+    simple_py.write_text("print('hi')\n")
+
+    # create a zip archive containing the python file
+    zip_path = tmp_path / "example.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(simple_py, arcname="example.py")
+
+    # process the zip and ensure it is deleted afterwards
+    zip_pipeline.process_zip(zip_path)
+    assert not zip_path.exists()
+
+
+def test_discover_zip_files(tmp_path):
+    # create nested directories with zip files
+    (tmp_path / "a").mkdir()
+    zip1 = tmp_path / "a" / "one.zip"
+    with zipfile.ZipFile(zip1, "w"):
+        pass
+    zip2 = tmp_path / "two.zip"
+    with zipfile.ZipFile(zip2, "w"):
+        pass
+
+    found = zip_pipeline.discover_zip_files([str(tmp_path)])
+    assert zip1 in found and zip2 in found

--- a/tools/extract_slide_previews.py
+++ b/tools/extract_slide_previews.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Extract slide text previews and styled digital-twin hints from a PPTX and write:
+- slide_texts.json (full texts per slide)
+- slide_digital_twins.json (compact summary + style hints)
+- slide_preview.html (simple visual preview with inline CSS)
+
+Usage:
+  python tools/extract_slide_previews.py \
+    --pptx output/handover_final/QPLANT_comparison.pptx \
+    --outdir output/handover_final \
+    --limit 20
+"""
+import argparse
+import json
+from pathlib import Path
+
+try:
+    from pptx import Presentation
+except Exception:
+    raise SystemExit("python-pptx is required. pip install python-pptx")
+
+
+def extract_slides(pptx_path: Path, limit: int | None = None):
+    prs = Presentation(str(pptx_path))
+    slides = []
+    all_slides = list(prs.slides)
+    rng = all_slides[:limit] if limit else all_slides
+    for i, s in enumerate(rng):
+        texts = []
+        bullets = 0
+        for sh in s.shapes:
+            if hasattr(sh, 'text'):
+                t = (sh.text or '').strip()
+                if t:
+                    texts.append(t)
+                    if any(t.lstrip().startswith(ch) for ch in ('-', '•', '*')):
+                        bullets += 1
+        title = texts[0] if texts else ''
+        is_title = bool(title) and len(title) < 120 and title.upper() == title[: len(title)].upper()
+        bg = '#f0f8ff' if is_title else ('#ffffff' if bullets > 0 else '#fafafa')
+        slides.append({
+            'n': i + 1,
+            'texts': texts,
+            'shape_count': len(s.shapes),
+            'bullets': bullets,
+            'style_hint': {
+                'bg': bg,
+                'is_title': is_title,
+            },
+        })
+    return slides
+
+
+def write_html_preview(slides: list[dict], out_html: Path):
+    css = """
+    <style>
+      body{font-family:Arial,Helvetica,sans-serif;background:#111;color:#eee;margin:0;padding:24px}
+      .deck{display:flex;flex-wrap:wrap;gap:16px}
+      .card{width:360px;height:240px;border-radius:10px;box-shadow:0 2px 12px rgba(0,0,0,.4);padding:12px;overflow:auto}
+      .title{margin:4px 0 6px 0;color:#111}
+      .meta{font-size:12px;color:#444;margin-bottom:6px}
+      .para{margin:4px 0;color:#222;font-size:12px}
+      .num{background:#444;color:#fff;border-radius:6px;padding:2px 6px;font-size:11px}
+    </style>
+    """
+    parts = ["<html><head><meta charset='utf-8'><title>Slide Preview</title>", css, "</head><body>"]
+    parts.append("<h2>Slide Preview (first {} slides)</h2>".format(len(slides)))
+    parts.append("<div class='deck'>")
+    for s in slides:
+        bg = s.get('style_hint', {}).get('bg', '#ffffff')
+        texts = s.get('texts', [])
+        title = texts[0] if texts else ''
+        parts.append("<div class='card' style='background:{}'>".format(bg))
+        parts.append("<div class='meta'><span class='num'>#{} </span> • shapes:{} • bullets:{}</div>".format(s['n'], s['shape_count'], s['bullets']))
+        if title:
+            parts.append("<h3 class='title'>{}</h3>".format(title[:180]))
+        for t in texts[1:5]:
+            parts.append("<div class='para'>{}</div>".format(t[:220]))
+        parts.append("</div>")
+    parts.append("</div></body></html>")
+    out_html.write_text("\n".join(parts), encoding='utf-8')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--pptx', required=True)
+    ap.add_argument('--outdir', required=True)
+    ap.add_argument('--limit', type=int, default=20)
+    args = ap.parse_args()
+
+    pptx = Path(args.pptx)
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    slides = extract_slides(pptx, args.limit)
+
+    (outdir / 'slide_texts.json').write_text(json.dumps(slides, indent=2, ensure_ascii=False), encoding='utf-8')
+    twins = [
+        {
+            'slide': s['n'],
+            'summary': s['texts'][:3],
+            'style_hint': s['style_hint'],
+            'shape_count': s['shape_count'],
+            'bullets': s['bullets'],
+        }
+        for s in slides
+    ]
+    (outdir / 'slide_digital_twins.json').write_text(json.dumps(twins, indent=2, ensure_ascii=False), encoding='utf-8')
+    write_html_preview(slides, outdir / 'slide_preview.html')
+    print('WROTE:', outdir / 'slide_texts.json')
+    print('WROTE:', outdir / 'slide_digital_twins.json')
+    print('WROTE:', outdir / 'slide_preview.html')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `extract_slide_previews` tool to render PPTX slides into HTML cards and JSON summaries
- document slide preview workflow and usage in README
- cover slide extraction and preview generation with tests

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pptx')*


------
https://chatgpt.com/codex/tasks/task_e_68c14ebfe704832e97fecfbb3cf8f779