### PR TITLE
Add SEC index, KPI API, and CI patch workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,12 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Run tests
         run: make test
+      - name: Check SEC index
+        run: python scripts/build_sec_index.py --check
+      - name: Build patch bundle
+        run: bash scripts/patch_all.sh
+      - name: Upload patch bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: patch
+          path: patch.zip

--- a/docs/sec_sections.md
+++ b/docs/sec_sections.md
@@ -1,0 +1,10 @@
+SEC-08: complete DMAIC loop (Define → Measure → Analyze → Improve → Control) with round-trip hooks.
+SEC-09: artefact visibility + ranking + influence scores, both as a table and JSON graph.
+SEC-10: human-readable YAML/MD artefacts: bios.yaml, kpi_template.yml, artefact_index.yml, and README excerpt.
+SEC-11: patch & bundle scripts (patch_all.sh, patch_zip_userzip.sh) so you can spit out diffs and zips like a pro.
+SEC-12: structured “verbatim” user input with scope + reduced summaries (structured_input.yaml).
+SEC-13: smoke/regression tests (basic but real), so there’s at least something to fail besides our hopes.
+SEC-14: CD plan & expected outcomes (promotion gates, observability, reproducibility).
+SEC-15: generic agent roles for orchestration (pipeline_orchestrator, kpi_tracker, baseline_promoter, report_generator).
+SEC-16: dashboard wireframe schema (JSON) to feed a live UI later.
+SEC-17: short handover statement, because someone will inevitably ask “what is this?”

--- a/kpi_template.yml
+++ b/kpi_template.yml
@@ -1,0 +1,9 @@
+pass_rate:
+  threshold: 0.90
+  comparison: ">="
+defect_rate:
+  threshold: 0.05
+  comparison: "<="
+coverage_delta:
+  threshold: 0.05
+  comparison: ">="

--- a/scripts/build_sec_index.py
+++ b/scripts/build_sec_index.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Generate index.json from SEC sections in markdown files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SEC_RE = re.compile(r"^(SEC-\d+):\s*(.*)")
+
+
+def collect_sections(root: Path) -> list[dict[str, str]]:
+    """Collect SEC sections from all markdown files under *root*."""
+    sections: list[dict[str, str]] = []
+    for path in root.rglob("*.md"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = SEC_RE.match(line)
+            if match:
+                sections.append(
+                    {"id": match.group(1), "title": match.group(2), "file": str(path.relative_to(root))}
+                )
+    return sections
+
+
+def build_index(root: Path) -> dict[str, list[dict[str, str]]]:
+    return {"sections": collect_sections(root)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="only verify index is up to date")
+    args = parser.parse_args()
+
+    index_path = ROOT / "sec_index.json"
+    data = build_index(ROOT)
+
+    if args.check:
+        if not index_path.exists():
+            print("sec_index.json is missing")
+            return 1
+        existing = json.loads(index_path.read_text())
+        if existing != data:
+            print("sec_index.json is out of date")
+            return 1
+        return 0
+
+    index_path.write_text(json.dumps(data, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/patch_all.sh
+++ b/scripts/patch_all.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Generate a diff patch and zip bundle of the repository.
+set -euo pipefail
+
+git diff --binary > patch.diff
+zip -q patch.zip patch.diff
+

--- a/sec_index.json
+++ b/sec_index.json
@@ -1,0 +1,54 @@
+{
+  "sections": [
+    {
+      "id": "SEC-08",
+      "title": "complete DMAIC loop (Define \u2192 Measure \u2192 Analyze \u2192 Improve \u2192 Control) with round-trip hooks.",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-09",
+      "title": "artefact visibility + ranking + influence scores, both as a table and JSON graph.",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-10",
+      "title": "human-readable YAML/MD artefacts: bios.yaml, kpi_template.yml, artefact_index.yml, and README excerpt.",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-11",
+      "title": "patch & bundle scripts (patch_all.sh, patch_zip_userzip.sh) so you can spit out diffs and zips like a pro.",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-12",
+      "title": "structured \u201cverbatim\u201d user input with scope + reduced summaries (structured_input.yaml).",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-13",
+      "title": "smoke/regression tests (basic but real), so there\u2019s at least something to fail besides our hopes.",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-14",
+      "title": "CD plan & expected outcomes (promotion gates, observability, reproducibility).",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-15",
+      "title": "generic agent roles for orchestration (pipeline_orchestrator, kpi_tracker, baseline_promoter, report_generator).",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-16",
+      "title": "dashboard wireframe schema (JSON) to feed a live UI later.",
+      "file": "docs/sec_sections.md"
+    },
+    {
+      "id": "SEC-17",
+      "title": "short handover statement, because someone will inevitably ask \u201cwhat is this?\u201d",
+      "file": "docs/sec_sections.md"
+    }
+  ]
+}

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,1 @@
+"""API package for serving artefact graphs and KPIs."""

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,31 @@
+"""FastAPI service exposing artefact graph and KPI data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from fastapi import FastAPI
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+app = FastAPI()
+
+
+@app.get("/index")
+def read_index() -> dict:
+    """Return SEC index data."""
+    index_path = ROOT / "sec_index.json"
+    if index_path.exists():
+        return json.loads(index_path.read_text())
+    return {"sections": []}
+
+
+@app.get("/kpis")
+def read_kpis() -> dict:
+    """Return KPI thresholds."""
+    kpi_path = ROOT / "kpi_template.yml"
+    if kpi_path.exists():
+        return yaml.safe_load(kpi_path.read_text())
+    return {}


### PR DESCRIPTION
## Summary
- generate `sec_index.json` from markdown `SEC-*` entries
- expose index and KPI thresholds via FastAPI service
- produce patch bundle and verify SEC index in CI

## Testing
- `pytest`
- `make test` *(fails: flake8 missing and cannot be installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c19e383de0832e80204d2ef98ba271