### PR TITLE
fix: improve changelog robustness and workflow checkout

### DIFF
--- a/.github/workflows/req-changelog.yml
+++ b/.github/workflows/req-changelog.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -33,7 +33,15 @@ def main(req_id: str | None = None) -> None:
 
     If `req_id` is provided, only that requirement is processed.
     """
-    index_data = json.loads(Path("index.json").read_text())
+    index_path = Path("index.json")
+    try:
+        index_data = json.loads(index_path.read_text())
+    except FileNotFoundError:
+        print("Error: index.json not found in the current directory.", file=sys.stderr)
+        return
+    except json.JSONDecodeError:
+        print("Error: index.json contains invalid JSON.", file=sys.stderr)
+        return
     requirements = index_data["requirements"]
 
     if req_id:


### PR DESCRIPTION
## Summary
- handle missing or invalid index.json in changelog script
- fetch full git history in changelog workflow

## Testing
- `make test` *(fails: flake8: No such file or directory)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1acdd3a5c832e916b80c71e24db35