### PR TITLE
fix: address review feedback on type hints and title detection

### DIFF
--- a/src/zip_pipeline.py
+++ b/src/zip_pipeline.py
@@ -21,12 +21,12 @@ from pathlib import Path
 import subprocess
 import tempfile
 import zipfile
-from typing import Iterable, List
+from typing import Iterable
 
 
-def discover_zip_files(base_dirs: Iterable[str]) -> List[Path]:
+def discover_zip_files(base_dirs: Iterable[str]) -> list[Path]:
     """Return a sorted list of all ``.zip`` files under ``base_dirs``."""
-    paths: List[Path] = []
+    paths: list[Path] = []
     for base in base_dirs:
         paths.extend(Path(base).rglob("*.zip"))
     return sorted(paths)

--- a/tools/extract_slide_previews.py
+++ b/tools/extract_slide_previews.py
@@ -37,7 +37,7 @@ def extract_slides(pptx_path: Path, limit: int | None = None):
                     if any(t.lstrip().startswith(ch) for ch in ('-', '•', '*')):
                         bullets += 1
         title = texts[0] if texts else ''
-        is_title = bool(title) and len(title) < 120 and title.upper() == title[: len(title)].upper()
+        is_title = bool(title) and len(title) < 120 and title.isupper()
         bg = '#f0f8ff' if is_title else ('#ffffff' if bullets > 0 else '#fafafa')
         slides.append({
             'n': i + 1,


### PR DESCRIPTION
## Summary
- use builtin list for zip discovery results
- simplify slide title heuristic to `str.isupper`

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement flake8==7.1.1)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tools')*

------
https://chatgpt.com/codex/tasks/task_e_68c1ad77997c832e88967826fa874367