### PR TITLE
Add Colab demo and CLI example

### DIFF
--- a/DMAIC_v2.1.md
+++ b/DMAIC_v2.1.md
@@ -1,0 +1,16 @@
+# DMAIC Canvas – Repository Build v2.1
+
+## Define
+Provide a GitHub-ready repository structure with a Colab demo, example CLI script, and CI workflow.
+
+## Measure
+Confirm presence of `.gitignore`, `README.md`, `LICENSE`, `.github/workflows/ci.yml`, and example scripts.
+
+## Analyze
+Identify gaps in documentation and example usage to improve developer onboarding.
+
+## Improve
+Added `colab_demo.md`, `examples/cli_run.sh`, and recorded this canvas to track repository build decisions.
+
+## Control
+The CI workflow will ensure ongoing quality checks, and the example scripts serve as references for future contributors.

--- a/colab_demo.md
+++ b/colab_demo.md
@@ -1,0 +1,17 @@
+# Colab Demo
+
+This markdown file can be uploaded or pasted into a Google Colab notebook to generate plots and Cost of Poor Quality (COP) tables using the project's pipeline.
+
+## Setup
+
+```python
+!pip install -r requirements.txt
+```
+
+## Run the Pipeline
+
+```python
+!python app/run_pipeline.py --demo
+```
+
+The commands above produce plots and COP tables for analysis.

--- a/examples/cli_run.sh
+++ b/examples/cli_run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Example script demonstrating CLI usage of the DMAIC measure-phase pipeline.
+set -euo pipefail
+
+python app/run_pipeline.py "$@"


### PR DESCRIPTION
## Summary
- Provide `colab_demo.md` for running the pipeline in Google Colab
- Add `examples/cli_run.sh` as a simple CLI usage example
- Record repository build decisions in `DMAIC_v2.1.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1cc46b150832e8c20187def5c7532