### PR TITLE
Add Confluence export pipeline

### DIFF
--- a/ess_cryogenics_storage.html
+++ b/ess_cryogenics_storage.html
@@ -1,0 +1,123 @@
+<!-- ess_cryogenics_storage.html -->
+<p><strong>Source:</strong> <em>Cryogenic Technologies at the ESS</em> — ALX Copy: ALX/91586851</p>
+<p><strong>Permalinks:</strong> SCK Library: <em>link</em> &nbsp;|&nbsp; IOP: <em>link</em></p>
+
+<ac:structured-macro ac:name="toc">
+  <ac:parameter ac:name="minLevel">1</ac:parameter>
+  <ac:parameter ac:name="maxLevel">3</ac:parameter>
+</ac:structured-macro>
+
+<h1>Cryogenic Technologies at the ESS — Extract & Notes</h1>
+
+<h2>Metadata</h2>
+<table>
+  <tbody>
+    <tr><th>Field</th><th>Value</th></tr>
+    <tr><td>Work ID</td><td>ALX/91586851</td></tr>
+    <tr><td>SCK Library permalink</td><td>link</td></tr>
+    <tr><td>IOP Link</td><td>link</td></tr>
+  </tbody>
+</table>
+
+<h2>Book Content</h2>
+
+<h3>Chapter 1 — Introduction to the European Spallation Source</h3>
+<table>
+  <tbody>
+    <tr><th>Topic</th><th>Notes</th></tr>
+    <tr><td>ESS facility</td><td></td></tr>
+    <tr><td>Spoke cavity Cryomodule (CNRS &amp; CEA)</td><td></td></tr>
+    <tr>
+      <td>Funding</td>
+      <td>
+        <blockquote>
+        “The non-host states provide 52.5% of the construction costs; 70% of this is in the form of In-kind contributions and 30% is in cash.”
+        </blockquote>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Chapter 2 — ESS cryogenic system overview &amp; design evolution</h3>
+<table>
+  <tbody>
+    <tr><th>Topic</th><th>Notes</th></tr>
+    <tr><td>Block diagram / PID</td><td>High-level architecture and P&amp;ID references</td></tr>
+    <tr><td>Losses</td><td>
+      <blockquote>
+      “Total helium inventory at ESS is ~3.5&nbsp;t. Expected annual replacement: 30% during first 5 years (leaks &amp; operating errors), thereafter ≥25%.”
+      </blockquote>
+    </td></tr>
+    <tr><td>Safety factors (cooling capacity)</td><td>Accelerator &amp; target cryoplants: SF=1.8; early project SF≈2.0.</td></tr>
+    <tr><td>Mandatory PLC brand</td><td>
+      <blockquote>
+      “All PLCs must be Siemens S7-300 and/or S7-400 and/or S7-1500. Requirement extended to the majority of ESS control systems.”
+      </blockquote>
+    </td></tr>
+  </tbody>
+</table>
+
+<h3>Chapter 3 — The Accelerator Cryoplant</h3>
+<table>
+  <tbody>
+    <tr><th>Topic</th><th>Notes</th></tr>
+    <tr><td>Screenshots</td><td>(omitted placeholder)</td></tr>
+    <tr><td>Tender Technical Specifications</td><td>(omitted placeholder)</td></tr>
+    <tr><td>Tender Granting Criteria</td><td>
+      100 pts total: 30 CAPEX + 30 OPEX + 40 Quality. See Annex B for attribute weights (e.g., soundness, simplicity, completeness).
+    </td></tr>
+  </tbody>
+</table>
+
+<h3>Chapter 4 — Cryogenic distribution system (pp. 141–171)</h3>
+<table>
+  <tbody>
+    <tr><th>Topic</th><th>Notes</th></tr>
+    <tr><td>Engineering duration (Elliptical)</td><td>6 mo preliminary; 12 mo final</td></tr>
+    <tr><td>Engineering duration (Spoke)</td><td>21 mo preliminary; 18 mo final</td></tr>
+    <tr><td>Manufacturing</td><td>Elliptical (30): 30 mo; Spoke (13): 36 mo</td></tr>
+    <tr><td>Installation</td><td>Elliptical (30): 42 mo; Spoke (13): 33 mo</td></tr>
+    <tr><td>1st Commissioning</td><td>Elliptical (30): 9 mo; Spoke (13): 9 mo</td></tr>
+    <tr><td>Cryoline + WPS PID</td><td>Helium recovery line is vacuum-insulated; no conditioning valves on Cryoline</td></tr>
+    <tr><td>Alignment strategy</td><td>
+      Positioning vs. virtual interface points (center plane of QM &amp; QVB) with ±1&nbsp;mm required accuracy. Coarse on supports: ±45&nbsp;mm (V), ±35&nbsp;mm (H). Fine: 1&nbsp;mm/turn all directions.
+    </td></tr>
+    <tr><td>Commissioning steps</td><td>
+      Cleaning/conditioning → Leak tests of control valve seats → Cool-down → Surface temperature (cold spots) → Instrumentation tests at cryo T → 8&nbsp;K heat-load measurements → Warm-up.
+    </td></tr>
+    <tr><td>Lessons learned</td><td>
+      Endoscopic cleanliness checks of process pipes &amp; control valves before installation; verify valve seat leak-tightness; convection breakers on larger valve inserts.
+    </td></tr>
+  </tbody>
+</table>
+
+<h3>Chapter 9 — Spoke cavity cryomodules</h3>
+<table>
+  <tbody>
+    <tr><th>Topic</th><th>Notes</th></tr>
+    <tr><td>Compliance</td><td>PED 97/23/EC; AFS 2005/2; EN 13445 for PS calculations</td></tr>
+    <tr><td>Maintenance</td><td>Prefer welded interfaces to minimize leak rate; ensure (dis)connection design preserves reliability.</td></tr>
+    <tr><td>Q<sub>0</sub></td><td>(placeholder)</td></tr>
+  </tbody>
+</table>
+
+<h3>Chapter 10 — Cryogenics testing of elliptical cryomodules at ESS</h3>
+<p><em>SAT plan — placeholder for detailed steps</em></p>
+
+<h3>Chapter 11 — Cryomodule testing at Uppsala University</h3>
+<table>
+  <tbody>
+    <tr><th>Topic</th><th>Notes</th></tr>
+    <tr><td>FREIA layout</td><td>HNOSS</td></tr>
+    <tr><td>Heat-load measurements</td><td>Flowmeter; Calorimetric; Level-decrease; Heater-compensation</td></tr>
+    <tr><td>Ruptured safety relief disk</td><td>
+      <blockquote>
+      “Interlock not properly set while a cavity was powered. Quench raised cavity pressure to 1.7&nbsp;bara (above disk limit). Disk replaced; no cavity damage; re-cooled.”
+      </blockquote>
+    </td></tr>
+    <tr><td>Lessons learned</td><td>Issues stem from (1) liquefier (LHe production, main compressor, gasbag full) and (2) cryomodule (cold leaks, equipment faults, high field emission → higher heat loads).</td></tr>
+  </tbody>
+</table>
+
+<hr/>
+<p><em>Attribution: compiled from user-provided excerpts for internal engineering knowledge capture. Verify contractual citations against the authoritative publication.</em></p>

--- a/push_and_export_confluence.py
+++ b/push_and_export_confluence.py
@@ -1,0 +1,76 @@
+# push_and_export_confluence.py
+import os, sys, time, requests
+
+BASE_SITE = os.getenv("CONFLUENCE_BASE_SITE", "https://myrrha.atlassian.net")  # no trailing slash
+WIKI_BASE = f"{BASE_SITE}/wiki"
+EMAIL     = os.getenv("CONFLUENCE_EMAIL")      # your Atlassian account email
+API_TOKEN = os.getenv("CONFLUENCE_API_TOKEN")  # from https://id.atlassian.com/manage-profile/security/api-tokens
+
+SPACE_KEY       = os.getenv("SPACE_KEY", "YOURSPACE")   # e.g., 'MINERVA'
+PARENT_PAGE_ID  = os.getenv("PARENT_PAGE_ID")           # optional: numeric Confluence pageId (parent). Leave blank to create at space root.
+PAGE_TITLE      = os.getenv("PAGE_TITLE", "Cryogenic Technologies at the ESS — Extract & Notes")
+BODY_FILE       = os.getenv("BODY_FILE", "ess_cryogenics_storage.html")
+OUT_PDF         = os.getenv("OUT_PDF", "ESS_Cryogenics_Extract.pdf")
+
+auth = (EMAIL, API_TOKEN)
+
+def get_space_id(space_key: str) -> str:
+    r = requests.get(f"{WIKI_BASE}/api/v2/spaces", params={"keys": space_key}, auth=auth)
+    r.raise_for_status()
+    results = r.json().get("results", [])
+    if not results:
+        raise SystemExit(f"Space with key '{space_key}' not found.")
+    return results[0]["id"]
+
+def create_page(space_id: str, parent_id: str|None, title: str, storage_html: str) -> str:
+    body = {
+        "spaceId": space_id,
+        "status": "current",
+        "title": title,
+        "body": {"representation": "storage", "value": storage_html},
+    }
+    if parent_id:
+        body["parentId"] = parent_id
+    r = requests.post(f"{WIKI_BASE}/api/v2/pages", json=body, auth=auth)
+    r.raise_for_status()
+    return r.json()["id"]
+
+def update_page(page_id: str, storage_html: str):
+    body = {"body": {"representation": "storage", "value": storage_html}}
+    r = requests.put(f"{WIKI_BASE}/api/v2/pages/{page_id}", json=body, auth=auth)
+    r.raise_for_status()
+    return page_id
+
+def export_pdf(page_id: str, out_pdf: str):
+    # FlyingPDF export (Cloud): /wiki/spaces/flyingpdf/pdfpageexport.action?pageId=...
+    url = f"{WIKI_BASE}/spaces/flyingpdf/pdfpageexport.action"
+    with requests.get(url, params={"pageId": page_id}, stream=True, auth=auth) as r:
+        r.raise_for_status()
+        with open(out_pdf, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+    return out_pdf
+
+def main():
+    if not (EMAIL and API_TOKEN):
+        raise SystemExit("Set CONFLUENCE_EMAIL and CONFLUENCE_API_TOKEN env vars.")
+
+    with open(BODY_FILE, "r", encoding="utf-8") as f:
+        storage_html = f.read()
+
+    space_id = get_space_id(SPACE_KEY)
+    parent_id = PARENT_PAGE_ID if PARENT_PAGE_ID else None
+
+    # Create page (idempotence by title is not guaranteed; customize as needed)
+    page_id = create_page(space_id, parent_id, PAGE_TITLE, storage_html)
+    print(f"Created page id: {page_id}  → {WIKI_BASE}/pages/{page_id}")
+
+    # Optional: brief wait to ensure publish before export
+    time.sleep(3)
+
+    pdf_path = export_pdf(page_id, OUT_PDF)
+    print(f"PDF saved: {pdf_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add HTML storage snippet for ESS cryogenics notes
- script to publish Confluence page and export it to PDF using REST API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4226245a4832eb7645a5520177f44