### PR TITLE
Add build config, orchestration manifest, and artifact workflow

### DIFF
--- a/.github/workflows/qplant-build.yml
+++ b/.github/workflows/qplant-build.yml
@@ -1,0 +1,26 @@
+name: QPLANT Build & Export
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas
+      - name: Run recursive builder
+        run: python recursive_builder.py
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: qplant-outputs
+          path: outputs/**

--- a/MCB_Handover_Index_v4.3.md
+++ b/MCB_Handover_Index_v4.3.md
@@ -1,0 +1,138 @@
+# QPLANT / MINERVA — MCB Orchestration Handover (v4.3)
+
+**Date (UTC):** 2025-09-14 08:02:09
+
+This handover consolidates the session outputs into an operable package for the **Management/Model/Minimum Change Board (MCB) orchestration**.
+
+---
+
+## 1. Scope & Baseline
+
+- Baseline comprises **5 MASTER CANVAS** and automation toolchain (Python, Word/Excel VBA, Pandoc helper).
+- Versioning convention: **MASTER_Name_RevN.n** (increment **0.1** per accepted batch).
+- DMAIC control embedded; recursive builder supports **insert-at-position** with deterministic **renumbering** for **SR.#** and **Req.#**.
+
+---
+
+## 2. Artifact Inventory (Downloads)
+
+### 2.1 Governance & DMAIC
+- DMAIC Report (MD): `DMAIC_Iteration_v4.3.md`
+- DMAIC Report (TXT): `DMAIC_Iteration_v4.3.txt`
+
+### 2.2 Automation – Python
+- Recursive Builder: `recursive_builder.py`
+- Pandoc Export Helper: `pandoc_export.py`
+- Drive/GitHub Sync Stubs: `drive_github_sync.py`
+
+### 2.3 Office Automation – VBA
+- Word Formatting Macro: `Word_QPLANT_Format.bas`
+- Excel RTM Macro Pack: `Excel_QPLANT_RTM.bas`
+
+### 2.4 Session Doc
+- Cover Document (DOCX): `QPLANT_Recursive_Build_DMAIC_v4.3.docx`
+
+### 2.5 Data Samples / Templates
+- RTM Traceability (CSV): `RTM_Traceability_V4.1.csv`
+- RTM Traceability (JSON): `RTM_Traceability_V4.1.json`
+- RTM Excel (XLSX): `RTM_Traceability_V4.1.xlsx`
+
+---
+
+## 3. Configuration (edit and place alongside scripts)
+
+- Config template (download & adjust): [config.json](config.json)
+
+```json
+{
+  "master_tag": "MASTER_RTM_Rev0.0",
+  "rtm_json": "data/RTM_Master.json",
+  "sr_json": "data/SR_Master.json",
+  "dtm_json": "data/DTM_Master.json",
+  "batch_json": "data/Batch_New.json",
+  "export_root": "outputs"
+}
+```
+
+**Master JSON templates (empty/skeleton):**
+- RTM master: [data/RTM_Master.json](data/RTM_Master.json)
+- SR master:  [data/SR_Master.json](data/SR_Master.json)
+- DTM master: [data/DTM_Master.json](data/DTM_Master.json)
+- Batch sample: [data/Batch_New.json](data/Batch_New.json)
+
+---
+
+## 4. Orchestration Procedures (MCB)
+
+### 4.1 Batch Intake (10–30 items typical)
+1. Author prepares **Batch_New.json** with proposed **SR./Req./Del.** items including optional `insert_at` (1-based).
+2. Submit batch to MCB queue with **impact note** (affected ADR/OCD/OTC).
+
+### 4.2 Build & Validate
+```bash
+python recursive_builder.py
+# outputs/<MASTER_RTM_RevX.Y> created
+python pandoc_export.py outputs/<MASTER_RTM_RevX.Y>/RTM.md outputs/<MASTER_RTM_RevX.Y>/RTM.docx
+```
+
+### 4.3 Office QA
+- Import **RTM.csv** into Excel sheet **RTM_Traceability** then run:
+  - `RTM_InsertAndRenumber` (if manual insert)  
+  - `RTM_CheckMeasurability` (flags missing measurability)
+- Apply **Word** macro `QPLANT_ApplyStylesAndNumbering` to contract docs for **Heading 1/2/3** and **a)b)c)** clause lists.
+
+### 4.4 Decision & Release
+- MCB reviews generated **CHANGELOG.md** under the new release folder; if accepted, approve **Rev +0.1**.
+- Optional: Run Drive/GitHub sync.
+
+---
+
+## 5. Integration (Drive / GitHub)
+
+### 5.1 Google Drive (Colab)
+- Mount Drive in Colab and run builder (see notebook stub): [notebooks/GoogleColab_QPLANT_Orchestration.ipynb](notebooks/GoogleColab_QPLANT_Orchestration.ipynb)
+
+### 5.2 GitHub
+- Use repository with `/data`, `/outputs`, `/versioning`.
+- Add a CI workflow to publish artifacts on push (template): [.github/workflows/qplant-build.yml](.github/workflows/qplant-build.yml)
+
+---
+
+## 6. Numbering & Formatting Rules
+
+- **Req.#** and **SR.#** are **unique anchors**; inserts **shift** following items; renumber performed by builder/macros.
+- **Deliverable (Del.#)** is the **explicit measurability** child of **Req.#** (V&V linkage mandatory).
+- **Word styles:** Heading 1 → “1.”, Heading 2 → “1.1.”, Heading 3 → “1.1.1”.  
+- **RFO clause outline:** “a) b) c)” levels for contractual addenda.
+
+---
+
+## 7. Acceptance Criteria (per release)
+
+1. 100% SR→Req coverage; 100% Req→Del coverage; 100% Req has V&V methods.  
+2. ADR DD.# has parent SR.# and linked impacted Req.#.  
+3. OCD has failure/recovery matrices bound to interfaces (TP1/TP2).  
+4. OTC scoring sheet generated; QA/QC standards referenced in each measurable Req.#.  
+5. Exports succeed (CSV/MD/DOCX); macros pass; changelog present.
+
+---
+
+## 8. Roles & RACI
+
+- **Owner (AFA)** – Approves contract & gateway decisions.  
+- **MMO (MINERVA)** – QA/Change governance; Risk & Issue registers.  
+- **QPLANT** – System owner (design, integration, lifecycle).  
+- **QCELL (TP1)** – Service requestor. **QPLANT (TP2)** – Service provider.  
+- **TCO** – Requirements management oversight.
+
+---
+
+## 9. Appendices
+
+- Sample batch JSON schema and fields (see Batch_New.json).  
+- Safety & reliability notes (pneumatic vs. motorized actuation): evaluate MTBF/PFD in OCD risk tables and ADR decisions.  
+- Materials annex & code references (e.g., 304L vs 316L) to remain in **Canvas 5 Reference Annex**.
+
+---
+
+**End of Handover**

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+  "master_tag": "MASTER_RTM_Rev0.0",
+  "rtm_json": "data/RTM_Master.json",
+  "sr_json": "data/SR_Master.json",
+  "dtm_json": "data/DTM_Master.json",
+  "batch_json": "data/Batch_New.json",
+  "export_root": "outputs"
+}

--- a/data/Batch_New.json
+++ b/data/Batch_New.json
@@ -1,0 +1,11 @@
+{
+  "stakeholders": [
+    {"SR.#": 0, "insert_at": 1, "Title": "Owner Requirements", "Owner": "AFA", "Role": "Sponsor", "Rationale": "Contractual mandate"}
+  ],
+  "requirements": [
+    {"Req.#": 0, "insert_at": 1, "Type": "System", "Category": "Reliability", "Title": "Safety Interlocks", "Requirement": "Activate within 100 ms", "Measurability": "Timed test", "Verification": "Response test", "Validation": "Field demo", "Parent SR": 1, "Del.#": ""}
+  ],
+  "deliverables": [
+    {"Del.#": "Del.1", "Req.#": 1, "Title": "Interlock Test Report", "Evidence": "Test logs", "Verification": "Timed activation", "Validation": "Site acceptance"}
+  ]
+}

--- a/data/DTM_Master.json
+++ b/data/DTM_Master.json
@@ -1,0 +1,3 @@
+{
+  "deliverables": []
+}

--- a/data/RTM_Master.json
+++ b/data/RTM_Master.json
@@ -1,0 +1,3 @@
+{
+  "requirements": []
+}

--- a/data/SR_Master.json
+++ b/data/SR_Master.json
@@ -1,0 +1,3 @@
+{
+  "stakeholders": []
+}

--- a/notebooks/GoogleColab_QPLANT_Orchestration.ipynb
+++ b/notebooks/GoogleColab_QPLANT_Orchestration.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# QPLANT Orchestration – Colab Runner\nMount Drive, edit config.json paths, then run the builder."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')\n",
+    "print('Drive mounted. Place scripts & data under /content/drive/MyDrive/QPLANT')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install pandas\n",
+    "import json, subprocess, os\n",
+    "os.chdir('/content/drive/MyDrive/QPLANT')\n",
+    "print('CWD:', os.getcwd())\n",
+    "!python recursive_builder.py"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Provide MCB orchestration handover manifest outlining artifact inventory and procedures
- Include starter config and empty master templates with sample batch data
- Add Colab runner notebook and CI workflow for recursive builder

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c675520cfc832e9fc6c5bc2e9a24a8