### PR TITLE
Add S-Header PSV sizing bundle

### DIFF
--- a/calc/results.md
+++ b/calc/results.md
@@ -1,0 +1,6 @@
+# PSV Sizing — First Pass (Subcritical)
+Case: W = 0.200 kg/s (200 g/s), P1 = 1.65 bar(a), P2 = 1.05 bar(a), Kd = 0.90
+Required seat area (T = 300 K): 1.535e-3 m^2 → +10% margin → 1.689e-3 m^2 → Ø ≥ 46.4 mm.
+Check: at 20 K → 3.964e-4 m^2; at 80 K → 7.927e-4 m^2 (300 K governs).
+Tail-pipe Δp_built (300 K worst): DN100 → 0.035/0.070/0.105 bar at L=10/20/30 m (f=0.02).
+Decision: Balanced-bellows PSV (or Pilot) to desensitize variable backpressure.

--- a/diagrams/psv_scheme.mmd
+++ b/diagrams/psv_scheme.mmd
@@ -1,0 +1,13 @@
+%% Mermaid updated to user constraints
+flowchart LR
+  U[[User Volume]] -->|PSV 1.50 bar(a)| DISCH{Discharge Manifold}
+  DISCH --> S[S Header (1.05 bar(a))]
+  DISCH --> B[B Header]
+  S --> LP[(LP Suction / Recovery)]
+  B --> LP
+  note1[[Seat ≥ 1.69e-3 m² (Ø ≥ 46.4 mm)]]
+  note2[[Tail-pipe: DN100 ≤20 m; DN125 ~30 m]]
+  note3[[Balanced-Bellows PSV]]
+  note1 --- DISCH
+  note2 --- S
+  note3 --- U

--- a/params/s_header.yml
+++ b/params/s_header.yml
@@ -1,0 +1,18 @@
+session_id: USER.PSV.S-HEADER.v3
+gas: helium
+gamma: 1.66
+R_spec_JkgK: 2078.6
+Kd: 0.90
+set_pressure_abs_bar: 1.50
+relieving_pressure_abs_bar: 1.65
+backpressure_super_abs_bar: 1.05
+flows_gs:
+  nominal: 3
+  maximum: 200
+design_pick:
+  seat_area_m2_min: 0.001689
+  seat_diameter_mm_min: 46.4
+  tailpipe_min_id:
+    L_le_20m: DN100
+    L_approx_30m: DN125
+notes: Subcritical flow at P2/P1 = 0.636 (>0.488 critical ratio).

--- a/tests/control_plan.md
+++ b/tests/control_plan.md
@@ -1,0 +1,25 @@
+# Test & Control Plan (focused)
+
+Objective. Demonstrate stable relief without chatter; confirm backpressure limits and velocities for 200 g/s worst case, and functional margins for 3 g/s nominal.
+
+1. **Bench Set & Leak-Tightness**
+   1. Set PSV at 1.50 bar(a) (document CDTP & tolerance).
+   2. Seat leakage per manufacturer class at ambient and cold (if applicable).
+2. **Backpressure Simulation (Flow Bench / Site with Orifice Restrictor)**
+   1. Impose superimposed 1.05 bar(a) at outlet.
+   2. Emulate built-up for DN100 and DN125 with calibrated K-elements to target 0.07 bar and 0.035 bar respectively at 200 g/s.
+   3. Record: lift pressure, mass flow, outlet ripple (RMS), no chatter criterion.
+3. **Velocity / Mach Checks**
+   1. Verify v at tail-pipe exit ≤ 0.3 Ma (calculate from measured flow & local T).
+   2. If >0.3 Ma, qualify diffuser/silencer; re-run Step 2.
+4. **Integrated Routing Verification**
+   1. Measure actual line length, bends, K-factors; recompute Δp_built.
+   2. Acceptance: Δp_built ≤ 0.10 bar (gas) and total backpressure within PSV allowable per device type.
+   3. For balanced-bellows, confirm bellows area/limit pressure and stability with variable backpressure.
+5. **Controls Interaction**
+   1. Confirm CV remains NC through lift; apply dead-band & rate limit; CV may trim only after reseat margin restored.
+   2. Alarm thresholds: pre-lift at ≥ 0.9×1.50 = 1.35 bar(a); backpressure alarm at ≥ 80% of allowable.
+6. **Documentation (PED/CE)**
+   1. Sizing sheet (inputs, equations, margins).
+   2. Tail-pipe calc with as-built geometry.
+   3. FAT/SAT reports including traces and KPIs (lifts/1000 h, max Δp_built, RMS ripple).


### PR DESCRIPTION
## Summary
- record helium PSV sizing parameters for S-Header flow cases
- document first-pass seat sizing, tail-pipe backpressure estimates and device choice
- include mermaid scheme and focused test & control plan

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68c671a88da4832eb631a603bde2a050